### PR TITLE
fix initial --

### DIFF
--- a/src/args.js
+++ b/src/args.js
@@ -1,6 +1,9 @@
 const minimist = require("minimist");
 
 function getArgs(argString) {
+  if (argString[0] === "--") {
+    argString.shift();
+  }
   return minimist(argString, {
     string: ["default-test-path", "mc", "read"],
     default: {

--- a/tests/args.test.js
+++ b/tests/args.test.js
@@ -61,14 +61,6 @@ describe("utils", () => {
         })
       );
     });
-
-    it("mochitest params passed in", () => {
-      expect(_getArgs("-- --jsdebugger expressions")).toEqual(
-        paramDefaults({
-          _: ["--jsdebugger", "expressions"]
-        })
-      );
-    });
   });
 
   describe("getArgString", () => {
@@ -94,9 +86,17 @@ describe("utils", () => {
       );
     });
 
-    it("test path  included", () => {
+    it("test path included", () => {
       expect(
         getArgString(_getArgs("--jsdebugger --default-test-path foo/bar bazz"))
+      ).toEqual("--jsdebugger bazz");
+    });
+
+    it("initial dashes are removed", () => {
+      expect(
+        getArgString(
+          _getArgs("-- --jsdebugger --default-test-path foo/bar bazz")
+        )
       ).toEqual("--jsdebugger bazz");
     });
   });


### PR DESCRIPTION
fixes #24 

`yarn mochid` in debugger.html currently generates this command

```
$ yarn mochi -- --jsdebugger "browser_dbg-sources.js"
```

which creates

```
./mach mochitest --jsdebugger browser_dbg-sources.js devtools/client/debugger/new
```

when it should create

```
./mach mochitest --jsdebugger browser_dbg-sources.js 
```