### PR TITLE
Show Try Runs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+logs

--- a/README.md
+++ b/README.md
@@ -75,6 +75,21 @@ mochii --read result.log
 [dh]:https://github.com/devtools-html/debugger.html
 
 
+### Prettifying a Try Task
+
+Try runs can be difficult to understand. Try tasks can be especially difficult to follow because the logs have to be verbose to pinpoint when a test failed. Mochii can help format a try task so that you can focus on the failure.
+
+**Step 1:** Go to the task and copy the task id
+
+<img src='https://shipusercontent.com/cd3a65058dd13292d2584351b332b275/Screen%20Shot%202017-12-21%20at%209.21.56%20AM.png' title='Screen Shot 2017-12-21 at 9.21.56 AM.png' width=1022>
+
+**Step 2:** Go to your project and run `mochii --task <task-id>`
+
+<img src='https://shipusercontent.com/d9d3e2db7efe564fb42ee9354f162733/Screen%20Shot%202017-12-21%20at%209.34.13%20AM.png' title='Screen Shot 2017-12-21 at 9.34.13 AM.png' width=1080>
+
+
+You'll get the same mochii output you'd get if you ran `yarn mochi` locally :smiley:!
+
 ### Contributing to Mochii
 
 There are two ways to contribute to Mochii

--- a/bin/mochii.js
+++ b/bin/mochii.js
@@ -6,7 +6,7 @@ const path = require("path");
 const fs = require("fs");
 
 const { getArgs, getArgString } = require("../src/args");
-const { runMochitests, readOutput } = require("../index");
+const { runMochitests, readOutput, tryTask } = require("../index");
 
 function moveDirectory(args) {
   if (!shell.test("-d", args.mc)) {
@@ -33,7 +33,9 @@ const args = getArgs(argString);
 if (args.read) {
   const _path = path.join(__dirname, "..", args.read);
   const text = fs.readFileSync(_path, { encoding: "utf8" });
-  console.log(readOutput(text).join("\n"));
+  console.log(readOutput(text));
+} else if (args.task) {
+  tryTask(args.task);
 } else {
   run(args);
 }

--- a/index.js
+++ b/index.js
@@ -1,11 +1,13 @@
 const shell = require("shelljs");
 
 const fs = require("fs");
+const path = require("path");
 const chalk = require("chalk");
 const inquirer = require("inquirer");
 
 const { runner } = require("./src/runner");
 const { asyncExec } = require("./src/utils");
+const { fetchTaskLog, sanitizeTaskLog } = require("./src/try");
 
 async function rerun() {
   const { rerun } = await inquirer.prompt([
@@ -62,4 +64,16 @@ function readOutput(text, options = { ci: true }) {
   return out;
 }
 
-module.exports = { runMochitests, readOutput };
+async function tryTask(task) {
+  const body = await fetchTaskLog(task);
+  const sanitizedBody = sanitizeTaskLog(body);
+  const logPath = path.join(__dirname, `./logs/${task}.log`);
+  console.log(
+    `${chalk.blue("Mochii")} ${chalk.dim(`Task is available at ${logPath}`)}`
+  );
+  fs.writeFileSync(logPath, sanitizedBody);
+  const out = readOutput(sanitizedBody);
+  console.log(out);
+}
+
+module.exports = { runMochitests, readOutput, tryTask };

--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
   "scripts": {
     "test": "jest",
     "lint": "eslint --fix . && yarn prettier",
-    "prettier":
-      "prettier --write --trailing-comma=none bin/*.js tests/*.js index.js"
+    "prettier": "prettier --write --trailing-comma=none bin/*.js tests/*.js index.js"
   },
   "repository": {
     "type": "git",

--- a/src/args.js
+++ b/src/args.js
@@ -5,7 +5,7 @@ function getArgs (argString) {
     argString.shift();
   }
   return minimist(argString, {
-    string: ["default-test-path", "mc", "read"],
+    string: ["default-test-path", "mc", "read", "task"],
     boolean: ["interactive", "ci"],
     default: {
       mc: ".",

--- a/src/debugger.js
+++ b/src/debugger.js
@@ -26,7 +26,8 @@ const map = {
   SELECT_SOURCE: d => formatSource(d.source),
   LOAD_SOURCE_TEXT: d => formatSource(d.source),
   EVALUATE_EXPRESSION: d => `${d.input}`,
-  COMMAND: d => `${d.command}`
+  COMMAND: d => `${d.command}`,
+  ADD_SOURCES: d => d.sources.map(formatSource).join(", ")
 };
 
 // const emojis = {

--- a/src/try.js
+++ b/src/try.js
@@ -1,0 +1,32 @@
+var request = require("request");
+
+async function fetchTaskLog (task) {
+  return new Promise(resolve => {
+    const uri = `https://public-artifacts.taskcluster.net/${task}/0/public/logs/log_info.log`;
+    request({ uri, method: "GET", gzip: true }, function (
+      error,
+      response,
+      body
+    ) {
+      if (error) {
+      } else {
+        resolve(body);
+      }
+    });
+  });
+}
+function sanitizeLine (line) {
+  return line.replace(/^.*INFO - /, "");
+}
+
+function sanitizeTaskLog (log) {
+  return log
+    .split("\n")
+    .map(sanitizeLine)
+    .join("\n");
+}
+
+module.exports = {
+  fetchTaskLog,
+  sanitizeTaskLog
+};

--- a/tests/__snapshots__/index.test.js.snap
+++ b/tests/__snapshots__/index.test.js.snap
@@ -219,7 +219,7 @@ exports[`mochi error2.txt 1`] = `
    [2m[34m1 ADD_SOURCE[39m[22m[2m server1.conn0.child1/source27 - main.min.js[22m
    [2m[34m1 CONNECT[39m[22m[2m http://example.com/browser/devtools/client/debugger/new/test/mochitest/examples/doc-sourcemaps2.html[22m
    [2m[34m1 SET_EXPANDED_STATE[39m[22m[2m [22m
-   [2m[34m1 ADD_SOURCES[39m[22m[2m [22m
+   [2m[34m1 ADD_SOURCES[39m[22m[2m server1.conn0.child1/source27/originalSource-1c0ae945d47b2dab15732faa1ace1f04 - main.js[22m
    [2m[34m1 LOAD_SOURCE_TEXT[39m[22m[2m [32m[start][39m server1.conn0.child1/source27 - main.min.js[22m
 [33m[2m   Waiting on sources: main.js, main.min.js[22m[39m
  [36mTEST-PASS[39m Original sources exist -
@@ -294,7 +294,7 @@ exports[`mochi error2.txt 2`] = `
    [2m[34m1 ADD_SOURCE[39m[22m[2m server1.conn0.child1/source27 - main.min.js[22m
    [2m[34m1 CONNECT[39m[22m[2m http://example.com/browser/devtools/client/debugger/new/test/mochitest/examples/doc-sourcemaps2.html[22m
    [2m[34m1 SET_EXPANDED_STATE[39m[22m[2m [22m
-   [2m[34m1 ADD_SOURCES[39m[22m[2m [22m
+   [2m[34m1 ADD_SOURCES[39m[22m[2m server1.conn0.child1/source27/originalSource-1c0ae945d47b2dab15732faa1ace1f04 - main.js[22m
    [2m[34m1 LOAD_SOURCE_TEXT[39m[22m[2m [32m[start][39m server1.conn0.child1/source27 - main.min.js[22m
 [33m[2m   Waiting on sources: main.js, main.min.js[22m[39m
  [36mTEST-PASS[39m Original sources exist -


### PR DESCRIPTION
This makes it easy to format try tasks (chunks) so that you don't have to squint/cmd+f those crazy log streams

Typical Task Log:

![](http://g.recordit.co/qvrCv7r1zx.gif)

The same log after it's been formatted by Mochii

![](http://g.recordit.co/wKL758VOUB.gif)

Mochii Screenshot

<img width="1080" alt="screen shot 2017-12-21 at 9 34 13 am" src="https://user-images.githubusercontent.com/254562/34260306-66f5fc9e-e633-11e7-96c9-2847547bd803.png">

Crazy verbose log :)

<img width="1023" alt="screen shot 2017-12-21 at 9 28 42 am" src="https://user-images.githubusercontent.com/254562/34260311-6f109d58-e633-11e7-88c5-132728c63890.png">
